### PR TITLE
Initialize Version with either int or data

### DIFF
--- a/samples/hello/hello.py
+++ b/samples/hello/hello.py
@@ -47,12 +47,12 @@ async def handle_connection(conn, loop):
                 # TODO: need a better system of handling all these actions
                 # The additional bytes read inside this conditional are Writeables based on the specific request
                 if action == 'internal:tcp/handshake':
-                    # Writeable data for this action is a BytesReference of length 4 which parses to vint version
+                    # Writeable data for this action is a BytesReference of length 4
                     data = input.read_bytes(input.read_array_size())
-                    # 0xa38eb741 -> 3000099
-                    os_version_int = StreamInput(data).read_v_int()
+                    # Internally this is a vint 0xa38eb741 -> 3000099 ^ MASK                    
+                    os_version_int = StreamInput(data).read_v_int() ^ Version.MASK
                     os_version = Version(os_version_int)
-                                       
+
                     # response_header = TcpHeader(request_id=header.request_id, status=header.status, size=TcpHeader.HEADER_SIZE, version=header.version)
                     # response_header.set_response()
                     #
@@ -62,7 +62,7 @@ async def handle_connection(conn, loop):
                     # variable_header.write_byte(0)
                     # variable_header.write_byte(0)
                     #
-                    #variable_header.write_v_int(99 | 0x08000000)
+                    # variable_header.write_v_int(Version(300099).id)
                     #
                     # variable_bytes = variable_header.getvalue()
                     # response_header.variable_header_size = len(variable_bytes)

--- a/src/opensearch_sdk_py/transport/tcp_header.py
+++ b/src/opensearch_sdk_py/transport/tcp_header.py
@@ -33,7 +33,7 @@ class TcpHeader:
         self.size = input.read_int()
         self.request_id = input.read_long()
         self.status = input.read_byte()
-        self.version = Version(input.read_int())
+        self.version = Version(data = input.read_bytes(4))
         self.variable_header_size = input.read_int()
         # print(f"remaining: {input.read_bytes(self.variable_header_size)}")
 

--- a/src/opensearch_sdk_py/transport/version.py
+++ b/src/opensearch_sdk_py/transport/version.py
@@ -1,10 +1,15 @@
 class Version:
     MASK = 0x08000000
 
-    def __init__(self, id: int):
-        self.data = id
-        self.id = id ^ Version.MASK
-        id &= 0xF7FFFFFF
+    def __init__(self, id: int=0, data:bytes=None):
+        if data == None:
+            # OpenSearch flips 25th bit to sort higher than legacy versions
+            self.id = id ^ Version.MASK
+        else:
+            # If we have data bytes use directly for id without bit-flip
+            self.id = int.from_bytes(data, "big")             
+        # String parsing strips 25th bit
+        id = self.id & 0xF7FFFFFF
         self.major = int((id / 1000000) % 100)
         self.minor = int((id / 10000) % 100)
         self.revision = int((id / 100) % 100)
@@ -14,4 +19,4 @@ class Version:
         return f"{self.major}.{self.minor}.{self.revision}.{self.build}"
             
     def __bytes__(self):
-        return self.data.to_bytes(4, byteorder='big')
+        return self.id.to_bytes(4, byteorder='big')

--- a/tests/opensearch_sdk_py/transport/test_version.py
+++ b/tests/opensearch_sdk_py/transport/test_version.py
@@ -4,12 +4,31 @@ from opensearch_sdk_py.transport.version import Version
 
 class TestVersion(unittest.TestCase):
     def test_2_10_0_99(self):
-        v = Version(136317827)
-        self.assertEqual(v.id, 2100099)
+        v = Version(2100099)
+        self.assertEqual(v.id, 136317827)
         self.assertEqual(v.major, 2)
         self.assertEqual(v.minor, 10)
         self.assertEqual(v.revision, 0)
         self.assertEqual(v.build, 99)
-        self.assertEqual(v.data, 136317827)
         self.assertEqual(str(v), '2.10.0.99')
         self.assertEqual(bytes(v), b'\x08 \x0b\x83')
+
+    def test_2_10_0_99_data(self):
+        v = Version(data = b'\x08 \x0b\x83')
+        self.assertEqual(v.id, 136317827)
+        self.assertEqual(v.major, 2)
+        self.assertEqual(v.minor, 10)
+        self.assertEqual(v.revision, 0)
+        self.assertEqual(v.build, 99)
+        self.assertEqual(str(v), '2.10.0.99')
+        self.assertEqual(bytes(v), b'\x08 \x0b\x83')
+
+    def test_empty(self):
+        v = Version()
+        self.assertEqual(v.id, Version.MASK)
+        self.assertEqual(v.major, 0)
+        self.assertEqual(v.minor, 0)
+        self.assertEqual(v.revision, 0)
+        self.assertEqual(v.build, 0)
+        self.assertEqual(str(v), '0.0.0.0')
+        self.assertEqual(bytes(v), b'\x08\x00\x00\x00')


### PR DESCRIPTION
OpenSearch `Version` class is intended to be initialized with a user-readable int value (e.g., 2100099).

Updated the version class to take either an int (where we toggle the 25th bit) or 4 bytes which are assumed to come from data where the bit has already been flipped.