### PR TITLE
Working TCP and Transport handshake actions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 __pycache__
 
+.vscode/**

--- a/samples/hello/hello.py
+++ b/samples/hello/hello.py
@@ -47,12 +47,12 @@ async def handle_connection(conn, loop):
                 # TODO: need a better system of handling all these actions
                 # The additional bytes read inside this conditional are Writeables based on the specific request
                 if action == 'internal:tcp/handshake':
-                    # Writeable data for this action is a BytesReference of length 4 which parses to vint version
+                    # Writeable data for this action is a BytesReference of length 4
                     data = input.read_bytes(input.read_array_size())
-                    # 0xa38eb741 -> 3000099
-                    os_version_int = StreamInput(data).read_v_int()
+                    # Internally this is a vint 0xa38eb741 -> 3000099 ^ MASK                    
+                    os_version_int = StreamInput(data).read_v_int() ^ Version.MASK
                     os_version = Version(os_version_int)
-                                       
+
                     # response_header = TcpHeader(request_id=header.request_id, status=header.status, size=TcpHeader.HEADER_SIZE, version=header.version)
                     # response_header.set_response()
                     #
@@ -62,7 +62,7 @@ async def handle_connection(conn, loop):
                     # variable_header.write_byte(0)
                     # variable_header.write_byte(0)
                     #
-                    #variable_header.write_v_int(99 | 0x08000000)
+                    # variable_header.write_v_int(Version(300099).id)
                     #
                     # variable_bytes = variable_header.getvalue()
                     # response_header.variable_header_size = len(variable_bytes)

--- a/samples/hello/hello.py
+++ b/samples/hello/hello.py
@@ -78,9 +78,7 @@ async def handle_connection(conn, loop):
 
                     # Standard response header and variable header are part of NetworkMessage and subclasses
                     # TODO: This TcpHeader should probably be part of NetworkMessage class per earlier comment
-                    # TODO: this length should probably be a default size in the TcpHeader constructor or a constant or both
-                    message_length = TcpHeader.HEADER_SIZE - TcpHeader.MARKER_BYTES_SIZE - TcpHeader.MESSAGE_LENGTH_SIZE
-                    response_header = TcpHeader(request_id=header.request_id, status=header.status, size=message_length, version=header.version)
+                    response_header = TcpHeader(request_id=header.request_id, status=header.status, version=header.version)
                     response_header.set_response()
                     
                     # TODO: Variable header writing should be part of OutboundMessage class per earlier comment
@@ -132,9 +130,7 @@ async def handle_connection(conn, loop):
                     # and begin creating a response (NetworkMessage subclass followed by TransportMessage subclass)
 
                     # Standard response header and variable header are part of NetworkMessage and subclasses
-                    # Copied from above (obvious refactor candidate!)
-                    message_length = TcpHeader.HEADER_SIZE - TcpHeader.MARKER_BYTES_SIZE - TcpHeader.MESSAGE_LENGTH_SIZE
-                    response_header = TcpHeader(request_id=header.request_id, status=header.status, size=message_length, version=header.version)
+                    response_header = TcpHeader(request_id=header.request_id, status=header.status, version=header.version)
                     response_header.set_response()
                     
                     variable_header = StreamOutput()
@@ -235,9 +231,7 @@ async def handle_connection(conn, loop):
 
                     # Standard response header and variable header are part of NetworkMessage and subclasses
                     # TODO: This TcpHeader should probably be part of NetworkMessage class per earlier comment
-                    # TODO: this length should probably be a default size in the TcpHeader constructor or a constant or both
-                    message_length = TcpHeader.HEADER_SIZE - TcpHeader.MARKER_BYTES_SIZE - TcpHeader.MESSAGE_LENGTH_SIZE
-                    response_header = TcpHeader(request_id=header.request_id, status=header.status, size=message_length, version=header.version)
+                    response_header = TcpHeader(request_id=header.request_id, status=header.status, version=header.version)
                     response_header.set_response()
 
                     # TODO: Variable header writing should be part of OutboundMessage class per earlier comment

--- a/samples/hello/hello.py
+++ b/samples/hello/hello.py
@@ -20,10 +20,14 @@ async def handle_connection(conn, loop):
             # output = StreamOutput(loop, conn)
             input = StreamInput(raw)
             print(f"\nreceived {input}, {len(raw)} byte(s)\n\t#{str(raw)}")
+
+            # TODO: Refactor TcpHeader reading into NetworkMessage class
             header = TcpHeader()
             header.read_from(input)
             print(f"\t{header}")
 
+            # TODO: Refactor headers into a ThreadContext class
+            # TODO: Refactor Thread Context reading into OutboundMessage(NetworkMessage) class
             # Thread Context written for both request and response
             request_headers = input.read_string_to_string_dict()
             if len(request_headers):
@@ -35,6 +39,8 @@ async def handle_connection(conn, loop):
 
             # Features and actions only written for requests
             if header.is_request():
+                # TODO: Refactor reading features and action name into Request(OutboundMessage) class
+                # TODO: Also create a Response(OutboundMessage) class that doesn't read these
                 features = input.read_string_array()
                 if len(features):
                     print(f"\tfeatures: {features}")
@@ -42,36 +48,69 @@ async def handle_connection(conn, loop):
                 action = input.read_string()
                 print(f"\taction: {action}")
 
+                # TODO: We switch here from NetworkMessage subclasses to TransportMessage subclasses
+                # Bytes read in NetworkMessage are added to both message and variable header length
+                # Bytes read in TransportMessage are only added to message length
+
+                # TODO: Create TransportMessage class
+                # TODO: Refactor reading TaskId into TransportRequest(TransportMessage) class
+                # TODO: Also have a TransportResponse(TransportMessage) class that doesn't read anything
                 task_id = TaskId()
                 task_id.read_from(input)
 
-                # TODO: need a better system of handling all these actions
+                # TODO: Need a better way of mathing these action names to reading their classes
                 # The additional bytes read inside this conditional are Writeables based on the specific request
                 if action == 'internal:tcp/handshake':
-                    # Writeable data for this action is a BytesReference of length 4
+                    # TODO: refactor into HandshakeRequest class. Note OpenSearch has two HandshakeRequest classes.
+                    # This one is o.o.transport.TransportHandshaker.HandshakeRequest. 
+                    # It reads/writes vint vesrsion wrapped in BytesReference
+                    # Other one is o.o.transport.HandshakeRequest used for internal:transport/handshake. 
+
+                    # TODO, consider BytesReference reading in streaminput.  First read the size
+                    # Note version as a writeable uses a vint, while version in TCP header is bigendian int
                     data = input.read_bytes(input.read_array_size())
                     # Internally this is a vint 0xa38eb741 -> 3000099 ^ MASK                    
                     os_version_int = StreamInput(data).read_v_int() ^ Version.MASK
                     os_version = Version(os_version_int)
 
-                    # Standard response header and variable header, need to refactor from here to the interesting part
-                    # TODO: this should probably be a default size in the TcpHeader constructor or a constant or both
+                    # TODO: Here we end the reading of the request writeables (TransportMessage subclass)
+                    # and begin creating a response (NetworkMessage subclass followed by TransportMessage subclass)
+
+                    # Standard response header and variable header are part of NetworkMessage and subclasses
+                    # TODO: This TcpHeader should probably be part of NetworkMessage class per earlier comment
+                    # TODO: this length should probably be a default size in the TcpHeader constructor or a constant or both
                     message_length = TcpHeader.HEADER_SIZE - TcpHeader.MARKER_BYTES_SIZE - TcpHeader.MESSAGE_LENGTH_SIZE
                     response_header = TcpHeader(request_id=header.request_id, status=header.status, size=message_length, version=header.version)
                     response_header.set_response()
                     
+                    # TODO: Variable header writing should be part of OutboundMessage class per earlier comment
                     variable_header = StreamOutput()
                     # These bytes are the context maps
-                    variable_header.write_byte(0)
-                    variable_header.write_byte(0)
-                    # No features on a response
+                    # TODO: Refactor this by implementing writing the thread context 
+                    variable_header.write_v_int(len(request_headers))
+                    for key in request_headers:
+                        variable_header.write_string(key)
+                        variable_header.write_string(request_headers[key])
+                    variable_header.write_v_int(len(response_headers))
+                    for key in response_headers:
+                        variable_header.write_string(key)
+                        variable_header.write_string_array(response_headers[key])
 
-                    # Here's the interesting part of this response.
+                    # TODO: Here we switch from NetworkMessage subclass to TransportMessage subclass
+                    # Bytes here don't count against variable header length but are added to total message length
                     writeable_data = StreamOutput()
+                    # TODO: refactor into HandshakeResponse class. Note OpenSearch has two HandshakeResponse classes.
+                    # This one is o.o.transport.TransportHandshaker.HandshakeResponse
+                    # Unlike the request which wraps version in a BytesReference we just directly write vint
                     # Version.CURRENT
                     writeable_data.write_v_int(current_version_id)
                     
-                    # Interesting part complete, back to math to assemble the pieces
+                    # Done with the NetworkMessage and TransportMessage
+
+                    # TODO: Doing math here to set values in TCP header but this math should be refactored to be accounted for
+                    # in the NetworkMessage (response & variable header) and TransportMessage (writeable bytes) classes
+                    # Note we need to know the header lengths for the initial response header class before writing it to
+                    # the overall stream. 
                     variable_bytes = variable_header.getvalue()
                     response_header.variable_header_size = len(variable_bytes)
                     response_header.size += response_header.variable_header_size
@@ -79,6 +118,8 @@ async def handle_connection(conn, loop):
                     writeable_bytes = writeable_data.getvalue()
                     response_header.size += len(writeable_bytes)
 
+                    # In OpenSearch these values are written by skipping the header in the stream and then going back
+                    # to start of stream to write it. Here we just assemble the parts and write together at the end.
                     output = StreamOutput()
                     response_header.write_to(output)
                     output.write(variable_bytes)
@@ -90,32 +131,49 @@ async def handle_connection(conn, loop):
                     
                     await loop.sock_sendall(conn, output.getvalue())
                 elif action == 'internal:transport/handshake':
-                    # No writeable data for this request action, we just send a response
+                    # TODO: refactor into HandshakeRequest class. Note OpenSearch has two HandshakeRequest classes.
+                    # This one is o.o.transport.HandshakeRequest. Doesn't read anything in.
 
-                    # Standard response header and variable header, need to refactor from here to the interesting part
-                    # TODO: this should probably be a default size in the TcpHeader constructor or a constant or both
+                    # TODO: Here we end the reading of the request writeables (TransportMessage subclass)
+                    # and begin creating a response (NetworkMessage subclass followed by TransportMessage subclass)
+
+                    # Standard response header and variable header are part of NetworkMessage and subclasses
+                    # Copied from above (obvious refactor candidate!)
                     message_length = TcpHeader.HEADER_SIZE - TcpHeader.MARKER_BYTES_SIZE - TcpHeader.MESSAGE_LENGTH_SIZE
                     response_header = TcpHeader(request_id=header.request_id, status=header.status, size=message_length, version=header.version)
                     response_header.set_response()
                     
                     variable_header = StreamOutput()
                     # These bytes are the context maps
-                    variable_header.write_byte(0)
-                    variable_header.write_byte(0)
-                    # No features on a response
+                    # TODO: Refactor this by implementing writing the thread context 
+                    variable_header.write_v_int(len(request_headers))
+                    for key in request_headers:
+                        variable_header.write_string(key)
+                        variable_header.write_string(request_headers[key])
+                    variable_header.write_v_int(len(response_headers))
+                    for key in response_headers:
+                        variable_header.write_string(key)
+                        variable_header.write_string_array(response_headers[key])
 
-                    # Here's the interesting part of this response.
+                    # TODO: Here we switch from NetworkMessage subclass to TransportMessage subclass
+                    # Bytes here don't count against variable header length but are added to total message length
                     writeable_data = StreamOutput()
+
+                    # TODO: refactor into HandshakeResponse class. Note OpenSearch has two HandshakeResponse classes.
+                    # This one is o.o.transport.HandshakeResponse
+                    # It writes am (Optional) DiscoveryNode, ClusterName (wraps a string), and Version
+
                     # OptionalWriteable(DiscoveryNode)
                     writeable_data.write_boolean(True) # optional is present
-                    # TODO: Refactor to an object
+                    # TODO: Refactor to a DiscoveryNode object. 
+                    # The discovery_extension_node implies one was written but not committed
                     # Begin DiscoveryNode object
                     writeable_data.write_string("hello-world");
                     writeable_data.write_string("nodeId");
                     writeable_data.write_string("ephemeralId");
                     writeable_data.write_string("127.0.0.1"); # hostName
                     writeable_data.write_string("127.0.0.1"); # hostAddress
-                    # TODO: Refactor to an object
+                    # TODO: Refactor to TransportAddress object. transport_address.py exists but needs the below code.
                     # Begin TransportAddress object
                     writeable_data.write_byte(4) # IP address has 4 bytes
                     writeable_data.write_byte(127) # The address
@@ -152,7 +210,9 @@ async def handle_connection(conn, loop):
                     # Version.CURRENT
                     writeable_data.write_v_int(current_version_id)
 
-                    # Interesting part complete, back to same math as before to assemble the pieces
+                    # Done with the NetworkMessage and TransportMessage
+
+                    # Back to same math as before to assemble the pieces
                     variable_bytes = variable_header.getvalue()
                     response_header.variable_header_size = len(variable_bytes)
                     response_header.size += response_header.variable_header_size
@@ -170,6 +230,78 @@ async def handle_connection(conn, loop):
                     print(f"\nsent handshake response, {len(raw_out)} byte(s):\n\t#{raw_out}\n\t{response_header}")
                     
                     await loop.sock_sendall(conn, output.getvalue())
+                elif action == 'internal:discovery/extensions':
+                    # TODO: implement InitializeExtensionRequest. Totally skipping reading the request 
+                    # until we have the DiscoveryNode and DiscoveryExtensionNode classes
+                    # we would also then send multiple requests to OpenSearch to implement extension points
+                    # before sending a response.
+                    # sometime between tcp and transport handshakes the uniqueId gets added to the thread context
+                    # so adding that here so it will get added to response headers
+                    request_headers['extension_unique_id'] = 'hello-world'
+
+                    # for now other than that thread context, we will just send the response to make OpenSearch 
+                    # happy that we initialized
+
+                    # TODO: Here we end the reading of the request writeables (TransportMessage subclass)
+                    # and begin creating a response (NetworkMessage subclass followed by TransportMessage subclass)
+
+                    # Standard response header and variable header are part of NetworkMessage and subclasses
+                    # TODO: This TcpHeader should probably be part of NetworkMessage class per earlier comment
+                    # TODO: this length should probably be a default size in the TcpHeader constructor or a constant or both
+                    message_length = TcpHeader.HEADER_SIZE - TcpHeader.MARKER_BYTES_SIZE - TcpHeader.MESSAGE_LENGTH_SIZE
+                    response_header = TcpHeader(request_id=header.request_id, status=header.status, size=message_length, version=header.version)
+                    response_header.set_response()
+
+                    # TODO: Variable header writing should be part of OutboundMessage class per earlier comment
+                    variable_header = StreamOutput()
+                    # These bytes are the context maps
+                    # TODO: Refactor this by implementing writing the thread context 
+                    variable_header.write_v_int(len(request_headers))
+                    for key in request_headers:
+                        variable_header.write_string(key)
+                        variable_header.write_string(request_headers[key])
+                    variable_header.write_v_int(len(response_headers))
+                    for key in response_headers:
+                        variable_header.write_string(key)
+                        variable_header.write_string_array(response_headers[key])
+
+                    # TODO: Here we switch from NetworkMessage subclass to TransportMessage subclass
+                    # Bytes here don't count against variable header length but are added to total message length
+                    writeable_data = StreamOutput()
+                    # TODO: refactor into InitializeExtensionResponse.
+                    # Write a string extension name, and then string array of implemented interfaces
+                    # Extension name comes from ExtensionSettings
+                    writeable_data.write_string('hello-world')
+                    # Implemented interfaces are collection of java class names
+                    # TODO: Implement write string array in Stream Output
+                    writeable_data.write_v_int(2)
+                    writeable_data.write_string('Extension')
+                    writeable_data.write_string('ActionExtension')
+                    
+                    # Done with the NetworkMessage and TransportMessage
+
+                    # TODO: Doing math here to set values in TCP header but this math should be refactored to be accounted for
+                    # in the NetworkMessage (response & variable header) and TransportMessage (writeable bytes) classes
+                    # Note we need to know the header lengths for the initial response header class before writing it to
+                    # the overall stream. 
+                    variable_bytes = variable_header.getvalue()
+                    response_header.variable_header_size = len(variable_bytes)
+                    response_header.size += response_header.variable_header_size
+
+                    writeable_bytes = writeable_data.getvalue()
+                    response_header.size += len(writeable_bytes)
+
+                    # In OpenSearch these values are written by skipping the header in the stream and then going back
+                    # to start of stream to write it. Here we just assemble the parts and write together at the end.
+                    output = StreamOutput()
+                    response_header.write_to(output)
+                    output.write(variable_bytes)
+                    output.write(writeable_bytes)
+                                        
+                    raw_out = output.getvalue()
+                    print(f"\tparsed Extension initialization request, returning a response")
+                    print(f"\nsent init response, {len(raw_out)} byte(s):\n\t#{raw_out}\n\t{response_header}")
+
                 else:
                     print(f"\tparsed action {header}, haven't yet written what to do with it")
             else:

--- a/samples/hello/hello.py
+++ b/samples/hello/hello.py
@@ -12,8 +12,6 @@ from opensearch_sdk_py.transport.handshake_response import HandshakeResponse
 from opensearch_sdk_py.transport.transport_address import TransportAddress
 
 async def handle_connection(conn, loop):
-    # TODO, probably should be a constant elsewhere
-    current_version_id = Version(3000099).id
     try:
         conn.setblocking(False)
         # out = StreamOutput(loop, conn)
@@ -95,8 +93,7 @@ async def handle_connection(conn, loop):
                     # TODO: refactor into HandshakeResponse class. Note OpenSearch has two HandshakeResponse classes.
                     # This one is o.o.transport.TransportHandshaker.HandshakeResponse
                     # Unlike the request which wraps version in a BytesReference we just directly write vint
-                    # Version.CURRENT
-                    writeable_data.write_v_int(current_version_id)
+                    writeable_data.write_v_int(Version.CURRENT)
                     
                     # Done with the NetworkMessage and TransportMessage
 
@@ -173,14 +170,14 @@ async def handle_connection(conn, loop):
                         writeable_data.write_string(r[1])
                         writeable_data.write_boolean(r[2])
                     # Version
-                    writeable_data.write_v_int(current_version_id)
+                    writeable_data.write_v_int(Version.CURRENT)
                     # End DiscoveryNode Object
 
                     # ClusterName
                     writeable_data.write_string("opensearch")
 
                     # Version.CURRENT
-                    writeable_data.write_v_int(current_version_id)
+                    writeable_data.write_v_int(Version.CURRENT)
 
                     # Done with the NetworkMessage and TransportMessage
 

--- a/samples/hello/hello.py
+++ b/samples/hello/hello.py
@@ -86,7 +86,7 @@ async def handle_connection(conn, loop):
                                         
                     raw_out = output.getvalue()
                     print(f"\tparsed TCP handshake, OpenSearch {os_version}, returning a response")
-                    print(f"\nsent handshake response , {len(raw_out)} byte(s):\n\t#{raw_out}\n\t{response_header}")
+                    print(f"\nsent handshake response, {len(raw_out)} byte(s):\n\t#{raw_out}\n\t{response_header}")
                     
                     await loop.sock_sendall(conn, output.getvalue())
                 elif action == 'internal:transport/handshake':
@@ -132,7 +132,7 @@ async def handle_connection(conn, loop):
                     writeable_data.write_v_int(4) 
                     writeable_data.write_string("cluster_manager")
                     writeable_data.write_string("m")
-                    writeable_data.write_boolean(True)
+                    writeable_data.write_boolean(False)
                     writeable_data.write_string("data")
                     writeable_data.write_string("d")
                     writeable_data.write_boolean(True)
@@ -167,7 +167,7 @@ async def handle_connection(conn, loop):
                                         
                     raw_out = output.getvalue()
                     print(f"\tparsed Transport handshake, returning a response")
-                    print(f"\nsent handshake response , {len(raw_out)} byte(s):\n\t#{raw_out}\n\t{response_header}")
+                    print(f"\nsent handshake response, {len(raw_out)} byte(s):\n\t#{raw_out}\n\t{response_header}")
                     
                     await loop.sock_sendall(conn, output.getvalue())
                 else:

--- a/samples/hello/hello.py
+++ b/samples/hello/hello.py
@@ -85,16 +85,10 @@ async def handle_connection(conn, loop):
                     
                     # TODO: Variable header writing should be part of OutboundMessage class per earlier comment
                     variable_header = StreamOutput()
-                    # These bytes are the context maps
+
                     # TODO: Refactor this by implementing writing the thread context 
-                    variable_header.write_v_int(len(request_headers))
-                    for key in request_headers:
-                        variable_header.write_string(key)
-                        variable_header.write_string(request_headers[key])
-                    variable_header.write_v_int(len(response_headers))
-                    for key in response_headers:
-                        variable_header.write_string(key)
-                        variable_header.write_string_array(response_headers[key])
+                    variable_header.write_string_to_string_dict(request_headers)
+                    variable_header.write_string_to_string_array_dict(response_headers)
 
                     # TODO: Here we switch from NetworkMessage subclass to TransportMessage subclass
                     # Bytes here don't count against variable header length but are added to total message length
@@ -144,16 +138,10 @@ async def handle_connection(conn, loop):
                     response_header.set_response()
                     
                     variable_header = StreamOutput()
-                    # These bytes are the context maps
+
                     # TODO: Refactor this by implementing writing the thread context 
-                    variable_header.write_v_int(len(request_headers))
-                    for key in request_headers:
-                        variable_header.write_string(key)
-                        variable_header.write_string(request_headers[key])
-                    variable_header.write_v_int(len(response_headers))
-                    for key in response_headers:
-                        variable_header.write_string(key)
-                        variable_header.write_string_array(response_headers[key])
+                    variable_header.write_string_to_string_dict(request_headers)
+                    variable_header.write_string_to_string_array_dict(response_headers)
 
                     # TODO: Here we switch from NetworkMessage subclass to TransportMessage subclass
                     # Bytes here don't count against variable header length but are added to total message length
@@ -254,16 +242,10 @@ async def handle_connection(conn, loop):
 
                     # TODO: Variable header writing should be part of OutboundMessage class per earlier comment
                     variable_header = StreamOutput()
-                    # These bytes are the context maps
+
                     # TODO: Refactor this by implementing writing the thread context 
-                    variable_header.write_v_int(len(request_headers))
-                    for key in request_headers:
-                        variable_header.write_string(key)
-                        variable_header.write_string(request_headers[key])
-                    variable_header.write_v_int(len(response_headers))
-                    for key in response_headers:
-                        variable_header.write_string(key)
-                        variable_header.write_string_array(response_headers[key])
+                    variable_header.write_string_to_string_dict(request_headers)
+                    variable_header.write_string_to_string_array_dict(response_headers)
 
                     # TODO: Here we switch from NetworkMessage subclass to TransportMessage subclass
                     # Bytes here don't count against variable header length but are added to total message length
@@ -273,10 +255,7 @@ async def handle_connection(conn, loop):
                     # Extension name comes from ExtensionSettings
                     writeable_data.write_string('hello-world')
                     # Implemented interfaces are collection of java class names
-                    # TODO: Implement write string array in Stream Output
-                    writeable_data.write_v_int(2)
-                    writeable_data.write_string('Extension')
-                    writeable_data.write_string('ActionExtension')
+                    writeable_data.write_string_array(['Extension', 'ActionExtension'])
                     
                     # Done with the NetworkMessage and TransportMessage
 

--- a/src/opensearch_sdk_py/transport/stream_input.py
+++ b/src/opensearch_sdk_py/transport/stream_input.py
@@ -160,7 +160,7 @@ class StreamInput:
         char_count = self.read_array_size()
         return str(self.read_bytes(char_count), 'ascii')
 
-    def read_string_array(self) -> [str]:
+    def read_string_array(self) -> list[str]:
         size = self.read_array_size()
         if size == 0:
             return []
@@ -171,7 +171,7 @@ class StreamInput:
 
         return result
 
-    def read_optional_string_array(self) -> [str]:
+    def read_optional_string_array(self) -> list[str]:
         if self.read_boolean():
             return self.read_string_array()
         else:

--- a/src/opensearch_sdk_py/transport/stream_input.py
+++ b/src/opensearch_sdk_py/transport/stream_input.py
@@ -4,23 +4,20 @@ from opensearch_sdk_py.transport.version import Version
 
 class StreamInput:
     def __init__(self, input):
-      self.raw = input
-      self.data = io.BytesIO(input)
+        self.raw = input
+        self.data = io.BytesIO(input)
 
     def read_byte(self) -> int:
-      return self.data.read(1)[0]
+        return self.data.read(1)[0]
     
     def read_bytes(self, len: int):
-      return self.data.read(len)
+        return self.data.read(len)
     
     def read_int(self) -> int:
-       return ((self.read_byte() & 0xFF) << 24) | ((self.read_byte() & 0xFF) << 16) | ((self.read_byte() & 0xFF) << 8) | (self.read_byte() & 0xFF)
-
-    def read_long(self) -> int:
-      return self.read_int() << 32 | self.read_int() & 0xFFFFFFFF
+        return ((self.read_byte() & 0xFF) << 24) | ((self.read_byte() & 0xFF) << 16) | ((self.read_byte() & 0xFF) << 8) | (self.read_byte() & 0xFF)
 
     def read_short(self) -> int:    
-      return (((self.read_byte() & 0xFF) << 8) | (self.read_byte() & 0xFF))
+        return (((self.read_byte() & 0xFF) << 8) | (self.read_byte() & 0xFF))
 
     def read_boolean(self):
         value = self.read_byte()
@@ -82,7 +79,7 @@ class StreamInput:
     # reads eight bytes and returns a long
     def read_long(self) -> int:
         return self.read_int() << 32 | self.read_int() & 0xFFFFFFFF
-    
+
     # reads a long stored in variable-length format
     def read_v_long(self) -> int:
         b = self.read_byte()

--- a/src/opensearch_sdk_py/transport/stream_output.py
+++ b/src/opensearch_sdk_py/transport/stream_output.py
@@ -3,7 +3,7 @@ from opensearch_sdk_py.transport.version import Version
 
 class StreamOutput(BytesIO):
     def write_byte(self, b: int):
-        return self.write(b.to_bytes(1))
+        return self.write(b.to_bytes(1, byteorder='big'))
 
     #  writes an int as four bytes.
     def write_int(self, i: int):

--- a/src/opensearch_sdk_py/transport/stream_output.py
+++ b/src/opensearch_sdk_py/transport/stream_output.py
@@ -24,7 +24,7 @@ class StreamOutput(BytesIO):
         return self.write(result)
       
     def write_version(self, version: Version):
-        return self.write(bytes(version))
+        return self.write_v_int(version.id)
 
     def write_long(self, i: int):
         return self.write(i.to_bytes(8, byteorder='big'))

--- a/src/opensearch_sdk_py/transport/stream_output.py
+++ b/src/opensearch_sdk_py/transport/stream_output.py
@@ -327,19 +327,11 @@ class StreamOutput(BytesIO):
     #     }
     # }
 
-    # /**
-    #  Writes a string array, for nullable string, writes it as 0 (empty string).
-    #  
-    # def writeStringArrayNullable(@Nullable String[] array) throws IOException {
-    #     if (array == null) {
-    #         writeVInt(0);
-    #     } else {
-    #         writeVInt(array.length);
-    #         for (String s : array) {
-    #             writeString(s);
-    #         }
-    #     }
-    # }
+    # writes a string array
+    def write_string_array(self, a: [str]):
+        self.write_v_int(len(a))
+        for s in a:
+            self.write_string(s)
 
     # /**
     #  Writes a string array, for nullable string, writes false.
@@ -356,6 +348,18 @@ class StreamOutput(BytesIO):
     # def writeMap(@Nullable Map<String, Object> map) throws IOException {
     #     writeGenericValue(map);
     # }
+
+    def write_string_to_string_dict(self, d: dict[str, str]):
+        self.write_v_int(len(d))
+        for k in d:
+            self.write_string(k)
+            self.write_string(d[k])
+
+    def write_string_to_string_array_dict(self, d: dict[str, list[str]]):
+        self.write_v_int(len(d))
+        for k in d:
+            self.write_string(k)
+            self.write_string_array(d[k])
 
     # /**
     #  write map to stream with consistent order

--- a/src/opensearch_sdk_py/transport/stream_output.py
+++ b/src/opensearch_sdk_py/transport/stream_output.py
@@ -281,12 +281,9 @@ class StreamOutput(BytesIO):
     # private static byte ONE = 1;
     # private static byte TWO = 2;
 
-    # /**
-    #  Writes a boolean.
-    #  
-    # def write_boolean(boolean b) throws IOException {
-    #     write_byte(b ? ONE : ZERO);
-    # }
+    # writes a boolean
+    def write_boolean(self, b: bool):
+        return self.write_byte(1 if b else 0)
 
     # def writeOptionalBoolean(@Nullable Boolean b) throws IOException {
     #     if (b == null) {

--- a/src/opensearch_sdk_py/transport/tcp_header.py
+++ b/src/opensearch_sdk_py/transport/tcp_header.py
@@ -33,7 +33,7 @@ class TcpHeader:
         self.size = input.read_int()
         self.request_id = input.read_long()
         self.status = input.read_byte()
-        self.version = Version(input.read_int())
+        self.version = Version(data = input.read_bytes(4))
         self.variable_header_size = input.read_int()
         # print(f"remaining: {input.read_bytes(self.variable_header_size)}")
 

--- a/src/opensearch_sdk_py/transport/tcp_header.py
+++ b/src/opensearch_sdk_py/transport/tcp_header.py
@@ -33,7 +33,7 @@ class TcpHeader:
         self.size = input.read_int()
         self.request_id = input.read_long()
         self.status = input.read_byte()
-        self.version = Version(data = input.read_bytes(4))
+        self.version = Version(data = input.read_bytes(4)) # always 4 bytes big-endian
         self.variable_header_size = input.read_int()
         # print(f"remaining: {input.read_bytes(self.variable_header_size)}")
 
@@ -42,7 +42,7 @@ class TcpHeader:
         output.write_int(self.size)
         output.write_long(self.request_id)
         output.write_byte(self.status)
-        output.write_version(self.version)
+        output.write(bytes(self.version)) # always 4 bytes big-endian
         output.write_int(self.variable_header_size)
 
     def __str__(self):

--- a/src/opensearch_sdk_py/transport/tcp_header.py
+++ b/src/opensearch_sdk_py/transport/tcp_header.py
@@ -43,7 +43,7 @@ class TcpHeader:
         output.write_long(self.request_id)
         output.write_byte(self.status)
         output.write_version(self.version)
-        output.write_byte(self.variable_header_size)
+        output.write_int(self.variable_header_size)
 
     def __str__(self):
         return f"{self.statuses} {self.prefix}, message={self.size} byte(s), request_id={self.request_id}, status={self.status}, version={self.version}"

--- a/src/opensearch_sdk_py/transport/tcp_header.py
+++ b/src/opensearch_sdk_py/transport/tcp_header.py
@@ -18,8 +18,9 @@ class TcpHeader:
     PRE_76_HEADER_SIZE = VERSION_POSITION + VERSION_ID_SIZE
     BYTES_REQUIRED_FOR_VERSION = PRE_76_HEADER_SIZE
     HEADER_SIZE = PRE_76_HEADER_SIZE + VARIABLE_HEADER_SIZE
+    MESSAGE_SIZE = HEADER_SIZE - BYTES_REQUIRED_FOR_MESSAGE_SIZE
 
-    def __init__(self, prefix='ES', request_id=1, status=0, version=None, size=-1, variable_header_size=0):
+    def __init__(self, prefix='ES', request_id=1, status=0, version=None, size=MESSAGE_SIZE, variable_header_size=0):
         self.prefix = prefix
         self.request_id = request_id
         self.status = status

--- a/src/opensearch_sdk_py/transport/tcp_header.py
+++ b/src/opensearch_sdk_py/transport/tcp_header.py
@@ -20,7 +20,7 @@ class TcpHeader:
     HEADER_SIZE = PRE_76_HEADER_SIZE + VARIABLE_HEADER_SIZE
     MESSAGE_SIZE = HEADER_SIZE - BYTES_REQUIRED_FOR_MESSAGE_SIZE
 
-    def __init__(self, prefix='ES', request_id=1, status=0, version=None, size=MESSAGE_SIZE, variable_header_size=0):
+    def __init__(self, prefix=b'ES', request_id=1, status=0, version=None, size=MESSAGE_SIZE, variable_header_size=0):
         self.prefix = prefix
         self.request_id = request_id
         self.status = status
@@ -39,7 +39,7 @@ class TcpHeader:
         # print(f"remaining: {input.read_bytes(self.variable_header_size)}")
 
     def write_to(self, output: StreamOutput):
-        output.write(bytes(self.prefix, 'ascii'))
+        output.write(self.prefix)
         output.write_int(self.size)
         output.write_long(self.request_id)
         output.write_byte(self.status)

--- a/src/opensearch_sdk_py/transport/tcp_header.py
+++ b/src/opensearch_sdk_py/transport/tcp_header.py
@@ -22,7 +22,7 @@ class TcpHeader:
     def __init__(self, prefix='ES', request_id=1, status=0, version=None, size=-1, variable_header_size=0):
         self.prefix = prefix
         self.request_id = request_id
-        self.status = TransportStatus.STATUS_HANDSHAKE
+        self.status = status
         self.version = version
         self.size = size
         self.variable_header_size = variable_header_size

--- a/src/opensearch_sdk_py/transport/version.py
+++ b/src/opensearch_sdk_py/transport/version.py
@@ -1,5 +1,6 @@
 class Version:
     MASK = 0x08000000
+    CURRENT = MASK | 3000099
 
     def __init__(self, id: int=0, data:bytes=None):
         if data == None:

--- a/src/opensearch_sdk_py/transport/version.py
+++ b/src/opensearch_sdk_py/transport/version.py
@@ -1,10 +1,15 @@
 class Version:
     MASK = 0x08000000
 
-    def __init__(self, id: int):
-        self.data = id
-        self.id = id ^ Version.MASK
-        id &= 0xF7FFFFFF
+    def __init__(self, id: int=0, data:bytes=None):
+        if data == None:
+            # OpenSearch flips 25th bit to sort higher than legacy versions
+            self.id = id ^ Version.MASK
+        else:
+            # If we have data bytes use directly for id without bit-flip
+            self.id = int.from_bytes(data, "big")             
+        # String parsing strips 25th bit
+        id = self.id & 0xF7FFFFFF
         self.major = int((id / 1000000) % 100)
         self.minor = int((id / 10000) % 100)
         self.revision = int((id / 100) % 100)
@@ -14,4 +19,4 @@ class Version:
         return f"{self.major}.{self.minor}.{self.revision}.{self.build}"
             
     def __bytes__(self):
-        return self.data.to_bytes(4, byteorder='big')
+        return self.id.to_bytes(4, byteorder='big')

--- a/tests/opensearch_sdk_py/transport/test_stream_input.py
+++ b/tests/opensearch_sdk_py/transport/test_stream_input.py
@@ -1,0 +1,147 @@
+import unittest
+
+from opensearch_sdk_py.transport.stream_input import StreamInput
+from opensearch_sdk_py.transport.version import Version
+
+class TestStreamInput(unittest.TestCase):
+    def test_read_byte(self):
+        input = StreamInput(b'\x2a')
+        self.assertEqual(input.read_byte(), 42)
+
+    def test_read_bytes(self):
+        input = StreamInput(b'\x27\x10\x42')
+        self.assertEqual(input.read_bytes(3), b'\x27\x10\x42')
+
+    def test_read_int(self):
+        input = StreamInput(b'\x00\x00\x00\x2a\x00\x00\x00\x2a\x00')
+        self.assertEqual(input.read_int(), 42)
+        self.assertEqual(input.read_int(), 42)
+        self.assertRaises(IndexError, input.read_int)
+
+    def test_read_short(self):
+        input = StreamInput(b'\x12\x34\x56\x78\x90')
+        self.assertEqual(input.read_short(), 4660)
+        self.assertEqual(input.read_short(), 22136)
+        self.assertRaises(IndexError, input.read_short)
+
+    def test_read_boolean(self):
+        input = StreamInput(b'\x00\x01\x02')
+        self.assertEqual(input.read_boolean(), False)
+        self.assertEqual(input.read_boolean(), True)
+        self.assertRaises(Exception, input.read_boolean)
+
+    def test_read_optional_boolean(self):
+        input = StreamInput(b'\x00\x01\x02\x03')
+        self.assertEqual(input.read_optional_boolean(), False)
+        self.assertEqual(input.read_optional_boolean(), True)
+        self.assertEqual(input.read_optional_boolean(), None)
+        self.assertRaises(Exception, input.read_optional_boolean)
+
+    def test_read_v_int(self):
+        input = StreamInput(b'\x2a')
+        self.assertEqual(input.read_v_int(), 42)
+        input = StreamInput(b'\x80\x01')
+        self.assertEqual(input.read_v_int(), 128)
+        input = StreamInput(b'\x80\x80\x01')
+        self.assertEqual(input.read_v_int(), 128**2)
+        input = StreamInput(b'\x80\x80\x80\x01')
+        self.assertEqual(input.read_v_int(), 128**3)
+        input = StreamInput(b'\x80\x80\x80\x80\x01')
+        self.assertEqual(input.read_v_int(), 128**4)
+        input = StreamInput(b'\x80\x80\x80\x80\x80\x01')
+        self.assertRaises(Exception, input.read_v_int)
+
+    def test_read_version(self):
+        input = StreamInput(b'\x83\x97\x80\x41')        
+        self.assertEqual(str(input.read_version()), '2.10.0.99')
+
+    def test_read_optional_int(self):
+        input = StreamInput(b'\x01\x00\x00\x00\x2a\x00\x01')
+        self.assertEqual(input.read_optional_int(), 42)
+        self.assertEqual(input.read_optional_int(), None)
+        self.assertRaises(IndexError, input.read_optional_int)
+
+    def test_read_long(self):
+        input = StreamInput(b'\x00\x00\x00\x01\x02\x03\x04\x05\x00\x00\x00\x01\x02\x03\x04\x05\x00')
+        self.assertEqual(input.read_long(), 4328719365)
+        self.assertEqual(input.read_long(), 4328719365)
+        self.assertRaises(IndexError, input.read_long)
+
+    def test_read_v_long(self):
+        input = StreamInput(b'\x2a')
+        self.assertEqual(input.read_v_long(), 42)
+        input = StreamInput(b'\x80\x01')
+        self.assertEqual(input.read_v_long(), 128)
+        input = StreamInput(b'\x80\x80\x01')
+        self.assertEqual(input.read_v_long(), 128**2)
+        input = StreamInput(b'\x80\x80\x80\x01')
+        self.assertEqual(input.read_v_long(), 128**3)
+        input = StreamInput(b'\x80\x80\x80\x80\x01')
+        self.assertEqual(input.read_v_long(), 128**4)
+        input = StreamInput(b'\x80\x80\x80\x80\x80\x01')
+        self.assertEqual(input.read_v_long(), 128**5)
+        input = StreamInput(b'\x80\x80\x80\x80\x80\x80\x01')
+        self.assertEqual(input.read_v_long(), 128**6)
+        input = StreamInput(b'\x80\x80\x80\x80\x80\x80\x80\x01')
+        self.assertEqual(input.read_v_long(), 128**7)
+        input = StreamInput(b'\x80\x80\x80\x80\x80\x80\x80\x80\x01')
+        self.assertEqual(input.read_v_long(), 128**8)
+        input = StreamInput(b'\x80\x80\x80\x80\x80\x80\x80\x80\x80\x01')
+        self.assertEqual(input.read_v_long(), 128**9)
+        input = StreamInput(b'\x80\x80\x80\x80\x80\x80\x80\x80\x80\x80\x01')
+        self.assertRaises(Exception, input.read_v_long)
+
+    def test_read_optional_v_long(self):
+        input = StreamInput(b'\x01\x80\x80\x80\x80\x80\x80\x80\x80\x80\x01')
+        self.assertEqual(input.read_optional_v_long(), 128**9)
+        input = StreamInput(b'\x00\x80\x80\x80\x80\x80\x80\x80\x80\x80\x01')
+        self.assertEqual(input.read_optional_v_long(), None)
+        input = StreamInput(b'\x01\x80\x80\x80\x80\x80\x80\x80\x80\x80\x80\x01')
+        self.assertRaises(Exception, input.read_optional_v_long)
+
+    def test_read_optional_long(self):
+        input = StreamInput(b'\x01\x00\x00\x00\x00\x00\x00\x00\x2a\x00\x01')
+        self.assertEqual(input.read_optional_long(), 42)
+        self.assertEqual(input.read_optional_long(), None)
+        self.assertRaises(IndexError, input.read_optional_long)
+
+    def test_read_optional_string(self):
+        input = StreamInput(b'\x01\x04test')        
+        self.assertEqual(input.read_optional_string(), 'test')
+        input = StreamInput(b'\x00\x04test')        
+        self.assertEqual(input.read_optional_string(), None)
+
+    def test_read_array_size(self):
+        input = StreamInput(b'\x2a')
+        self.assertEqual(input.read_array_size(), 42)
+        input = StreamInput(b'\x81\x80\x80\x80\x08') # 2**32+1
+        self.assertRaises(Exception, input.read_array_size)
+        # impossible to test rase on -1 as it can't ever happen
+
+    def test_read_string(self):
+        input = StreamInput(b'\x04test')        
+        self.assertEqual(input.read_string(), 'test')
+
+    def test_read_string_array(self):
+        input = StreamInput(b'\x02\x03foo\x03bar')        
+        self.assertEqual(input.read_string_array(), ['foo', 'bar'])
+
+    def test_read_optional_string_array(self):
+        input = StreamInput(b'\x01\x02\x03foo\x03bar')        
+        self.assertEqual(input.read_optional_string_array(), ['foo', 'bar'])
+        input = StreamInput(b'\x00\x02\x03foo\x03bar')        
+        self.assertEqual(input.read_optional_string_array(), None)
+
+    def test_read_string_to_string_dict(self):
+        input = StreamInput(b'\x02\x03foo\x03bar\x03baz\x03qux')
+        dict = input.read_string_to_string_dict()
+        self.assertEqual(len(dict), 2)
+        self.assertEqual(dict['foo'], 'bar')
+        self.assertEqual(dict['baz'], 'qux')
+
+    def test_read_string_to_string_array_dict(self):
+        input = StreamInput(b'\x02\x03foo\x02\x03bar\x03baz\x03qux\x00')
+        dict = input.read_string_to_string_array_dict()
+        self.assertEqual(len(dict), 2)
+        self.assertEqual(dict['foo'], ['bar', 'baz'])
+        self.assertEqual(dict['qux'], [])

--- a/tests/opensearch_sdk_py/transport/test_stream_output.py
+++ b/tests/opensearch_sdk_py/transport/test_stream_output.py
@@ -1,0 +1,71 @@
+import unittest
+
+from opensearch_sdk_py.transport.stream_output import StreamOutput
+from opensearch_sdk_py.transport.version import Version
+
+class TestStreamOutput(unittest.TestCase):
+    def test_write_byte(self):
+        out = StreamOutput()
+        out.write_byte(42)
+        self.assertEqual(out.getvalue(), b'\x2a')
+        self.assertRaises(OverflowError, out.write_byte, 256)
+
+    def test_write_int(self):
+        out = StreamOutput()
+        out.write_int(42)
+        self.assertEqual(out.getvalue(), b'\x00\x00\x00\x2a')
+
+    def test_write_v_int(self):
+        out = StreamOutput()
+        out.write_v_int(42)
+        self.assertEqual(out.getvalue(), b'\x2a')
+        # 7 bit max
+        out.seek(0,0)
+        out.write_v_int(127)
+        self.assertEqual(out.getvalue(), b'\x7f')
+        out.seek(0,0)
+        out.write_v_int(128)
+        self.assertEqual(out.getvalue(), b'\x80\x01')
+        # 14 bit max
+        out.seek(0,0)
+        out.write_v_int(16383)
+        self.assertEqual(out.getvalue(), b'\xff\x7f')
+        out.seek(0,0)
+        out.write_v_int(16384)
+        self.assertEqual(out.getvalue(), b'\x80\x80\x01')
+        # 21 bit max
+        out.seek(0,0)
+        out.write_v_int(2097151)
+        self.assertEqual(out.getvalue(), b'\xff\xff\x7f')
+        out.seek(0,0)
+        out.write_v_int(2097152)
+        self.assertEqual(out.getvalue(), b'\x80\x80\x80\x01')
+        # 28 bit max
+        out.seek(0,0)
+        out.write_v_int(268435455)
+        self.assertEqual(out.getvalue(), b'\xff\xff\xff\x7f')
+        out.seek(0,0)
+        out.write_v_int(268435456)
+        self.assertEqual(out.getvalue(), b'\x80\x80\x80\x80\x01')
+
+    def test_write_version(self):
+        out = StreamOutput()
+        v = Version(2100099)
+        out.write_version(v)
+        self.assertEqual(out.getvalue(), b'\x08\x20\x0b\x83')
+
+    def test_write_long(self):
+        out = StreamOutput()
+        out.write_long(5409454583320448)
+        self.assertEqual(out.getvalue(), b'\x00\x13\x37\xde\xca\xde\x0f\x80')
+
+    def test_write_string(self):
+        out = StreamOutput()
+        out.write_string("test")
+        self.assertEqual(out.getvalue(), b'\x04test')
+
+    def test_write_long(self):
+        out = StreamOutput()
+        out.write_boolean(True)
+        out.write_boolean(False)
+        self.assertEqual(out.getvalue(), b'\x01\x00')

--- a/tests/opensearch_sdk_py/transport/test_stream_output.py
+++ b/tests/opensearch_sdk_py/transport/test_stream_output.py
@@ -14,6 +14,7 @@ class TestStreamOutput(unittest.TestCase):
         out = StreamOutput()
         out.write_int(42)
         self.assertEqual(out.getvalue(), b'\x00\x00\x00\x2a')
+        self.assertRaises(OverflowError, out.write_int, 4294967296)
 
     def test_write_v_int(self):
         out = StreamOutput()
@@ -52,7 +53,7 @@ class TestStreamOutput(unittest.TestCase):
         out = StreamOutput()
         v = Version(2100099)
         out.write_version(v)
-        self.assertEqual(out.getvalue(), b'\x08\x20\x0b\x83')
+        self.assertEqual(out.getvalue(), b'\x83\x97\x80\x41')
 
     def test_write_long(self):
         out = StreamOutput()
@@ -64,7 +65,7 @@ class TestStreamOutput(unittest.TestCase):
         out.write_string("test")
         self.assertEqual(out.getvalue(), b'\x04test')
 
-    def test_write_long(self):
+    def test_write_boolean(self):
         out = StreamOutput()
         out.write_boolean(True)
         out.write_boolean(False)

--- a/tests/opensearch_sdk_py/transport/test_stream_output.py
+++ b/tests/opensearch_sdk_py/transport/test_stream_output.py
@@ -70,3 +70,24 @@ class TestStreamOutput(unittest.TestCase):
         out.write_boolean(True)
         out.write_boolean(False)
         self.assertEqual(out.getvalue(), b'\x01\x00')
+
+    def test_write_string_array(self):
+        out = StreamOutput()
+        out.write_string_array(['foo', 'bar'])
+        self.assertEqual(out.getvalue(), b'\x02\x03foo\x03bar')
+
+    def test_write_string_to_string_dict(self):
+        d = dict()
+        d['foo'] = 'bar'
+        d['baz'] = 'qux'
+        out = StreamOutput()
+        out.write_string_to_string_dict(d)
+        self.assertEqual(out.getvalue(), b'\x02\x03foo\x03bar\x03baz\x03qux')
+
+    def test_write_string_to_string_array_dict(self):
+        d = dict()
+        d['foo'] = ['bar', 'baz']
+        d['qux'] = []
+        out = StreamOutput()
+        out.write_string_to_string_array_dict(d)
+        self.assertEqual(out.getvalue(), b'\x02\x03foo\x02\x03bar\x03baz\x03qux\x00')

--- a/tests/opensearch_sdk_py/transport/test_task_id.py
+++ b/tests/opensearch_sdk_py/transport/test_task_id.py
@@ -1,0 +1,24 @@
+import unittest
+
+from opensearch_sdk_py.transport.stream_input import StreamInput
+from opensearch_sdk_py.transport.stream_output import StreamOutput
+from opensearch_sdk_py.transport.task_id import TaskId
+
+class TestTaskId(unittest.TestCase):
+    def test_task_id(self):
+        ti = TaskId('test', 42)
+        self.assertEqual(ti.node_id, 'test')
+        self.assertEqual(ti.id, 42)
+        out = StreamOutput()
+        ti.write_to(out)
+        self.assertEqual(out.getvalue(), b'\x04test\x00\x00\x00\x00\x00\x00\x00\x2a')
+
+        ti2 = TaskId()
+        ti2.read_from(input=StreamInput(out.getvalue()))
+        self.assertEqual(ti.node_id, 'test')
+        self.assertEqual(ti.id, 42)
+
+    def test_empty_task_id(self):
+        ti = TaskId()
+        self.assertEqual(ti.node_id, '')
+        self.assertEqual(ti.id, -1)

--- a/tests/opensearch_sdk_py/transport/test_task_id.py
+++ b/tests/opensearch_sdk_py/transport/test_task_id.py
@@ -22,3 +22,6 @@ class TestTaskId(unittest.TestCase):
         ti = TaskId()
         self.assertEqual(ti.node_id, '')
         self.assertEqual(ti.id, -1)
+        out = StreamOutput()
+        ti.write_to(out)
+        self.assertEqual(out.getvalue(), b'\x00')

--- a/tests/opensearch_sdk_py/transport/test_tcp_header.py
+++ b/tests/opensearch_sdk_py/transport/test_tcp_header.py
@@ -1,0 +1,45 @@
+import unittest
+
+from opensearch_sdk_py.transport.stream_input import StreamInput
+from opensearch_sdk_py.transport.stream_output import StreamOutput
+from opensearch_sdk_py.transport.tcp_header import TcpHeader
+from opensearch_sdk_py.transport.transport_status import TransportStatus
+from opensearch_sdk_py.transport.version import Version
+
+class TestTcpHeader(unittest.TestCase):
+    def test_tcp_header(self):
+        header = TcpHeader(version=Version(3000099))
+        self.assertEqual(header.prefix, b'ES')
+        self.assertEqual(header.request_id, 1)
+        self.assertTrue(header.is_request())
+        self.assertFalse(header.is_error())
+        self.assertFalse(header.is_compress())
+        self.assertFalse(header.is_handshake())
+        self.assertEqual(header.size, TcpHeader.MESSAGE_SIZE)
+        self.assertEqual(header.variable_header_size, 0)
+        self.assertEqual(str(header), "['request'] b'ES', message=17 byte(s), request_id=1, status=0, version=3.0.0.99")
+
+        header.set_response()
+        self.assertFalse(header.is_request())
+        header.set_request()
+        self.assertTrue(header.is_request())
+        header.set_error()
+        self.assertTrue(header.is_error())
+        header.set_compress()
+        self.assertTrue(header.is_compress())
+        header.set_handshake()
+        self.assertTrue(header.is_handshake())
+
+    def test_tcp_header_stream(self):
+        out = StreamOutput()
+        TcpHeader(request_id=2, version=Version(3000099), status=TransportStatus.STATUS_HANDSHAKE).write_to(out)
+        self.assertEqual(len(out.getvalue()), TcpHeader.HEADER_SIZE)
+
+        header = TcpHeader()
+        header.read_from(input=StreamInput(out.getvalue()))
+        self.assertEqual(header.prefix, b'ES')
+        self.assertEqual(header.request_id, 2)
+        self.assertTrue(header.is_handshake())
+        self.assertEqual(header.size, TcpHeader.MESSAGE_SIZE)
+        self.assertEqual(header.variable_header_size, 0)
+

--- a/tests/opensearch_sdk_py/transport/test_transport_address.py
+++ b/tests/opensearch_sdk_py/transport/test_transport_address.py
@@ -1,0 +1,38 @@
+import unittest
+
+from ipaddress import AddressValueError
+from opensearch_sdk_py.transport.stream_input import StreamInput
+from opensearch_sdk_py.transport.stream_output import StreamOutput
+from opensearch_sdk_py.transport.transport_address import TransportAddress
+
+class TestTransportAddress(unittest.TestCase):
+    def test_address_no_host(self):
+        ta = TransportAddress('1.2.3.4', 1234)
+        self.assertEqual(str(ta.address), '1.2.3.4')
+        self.assertEqual(int(ta.address), 16909060)
+        self.assertEqual(ta.host_name, '1.2.3.4')
+        self.assertEqual(ta.port, 1234)
+        out = StreamOutput()
+        ta.write_to(out)
+        self.assertEqual(out.getvalue(), b'\x04\x01\x02\x03\x04\x071.2.3.4\x00\x00\x04\xd2')
+
+    def test_address_with_host(self):
+        ta = TransportAddress('1.2.3.4', 1234, 'host.name')
+        self.assertEqual(str(ta.address), '1.2.3.4')
+        self.assertEqual(int(ta.address), 16909060)
+        self.assertEqual(ta.host_name, 'host.name')
+        self.assertEqual(ta.port, 1234)
+        out = StreamOutput()
+        ta.write_to(out)
+        self.assertEqual(out.getvalue(), b'\x04\x01\x02\x03\x04\x09host.name\x00\x00\x04\xd2')
+
+        ta2 = TransportAddress()
+        ta2.read_from(input=StreamInput(out.getvalue()))
+        self.assertEqual(str(ta2.address), '1.2.3.4')
+        self.assertEqual(int(ta2.address), 16909060)
+        self.assertEqual(ta2.host_name, 'host.name')
+        self.assertEqual(ta2.port, 1234)
+
+
+    def test_address_invalid(self):
+        self.assertRaises(AddressValueError, TransportAddress, '1.2.3.4.5', 1234)

--- a/tests/opensearch_sdk_py/transport/test_version.py
+++ b/tests/opensearch_sdk_py/transport/test_version.py
@@ -4,12 +4,31 @@ from opensearch_sdk_py.transport.version import Version
 
 class TestVersion(unittest.TestCase):
     def test_2_10_0_99(self):
-        v = Version(136317827)
-        self.assertEqual(v.id, 2100099)
+        v = Version(2100099)
+        self.assertEqual(v.id, 136317827)
         self.assertEqual(v.major, 2)
         self.assertEqual(v.minor, 10)
         self.assertEqual(v.revision, 0)
         self.assertEqual(v.build, 99)
-        self.assertEqual(v.data, 136317827)
         self.assertEqual(str(v), '2.10.0.99')
         self.assertEqual(bytes(v), b'\x08 \x0b\x83')
+
+    def test_2_10_0_99_data(self):
+        v = Version(data = b'\x08 \x0b\x83')
+        self.assertEqual(v.id, 136317827)
+        self.assertEqual(v.major, 2)
+        self.assertEqual(v.minor, 10)
+        self.assertEqual(v.revision, 0)
+        self.assertEqual(v.build, 99)
+        self.assertEqual(str(v), '2.10.0.99')
+        self.assertEqual(bytes(v), b'\x08 \x0b\x83')
+
+    def test_empty(self):
+        v = Version()
+        self.assertEqual(v.id, Version.MASK)
+        self.assertEqual(v.major, 0)
+        self.assertEqual(v.minor, 0)
+        self.assertEqual(v.revision, 0)
+        self.assertEqual(v.build, 0)
+        self.assertEqual(str(v), '0.0.0.0')
+        self.assertEqual(bytes(v), b'\x08\x00\x00\x00')


### PR DESCRIPTION
Sends the correct response from SDK to OpenSearch to complete the TCP and Transport handshakes.

Completes first and second request/response pair of #7; next step is to process the initialize request.

Implementations need refactoring into objects, looked into using existing ones but don't see `discovery_node.py` so I'm assuming there's uncommitted work somewhere.

Key TODO objects needed for transport (indented classes are subclasses) including length tracking
 - `NetworkMessage` (Some elements of TcpHeader plus ThreadContext)
   - `OutboundMessage` (Main class creating TCP Header and Variable Length Header components)
     - `OutboundMessage.Request` (Variable Length Header, contains features and action)
     - `OutboundMessage.Response`  (Variable Length Header)
 - `TransportMessage` (Length counts against message length but not variable header length)
   - `TransportRequest` (Includes TaskId)
     - `TransportHandshaker.HandshakeRequest` for tcp/handshake
     - `TransportService.HandshakeRequest` for transport/handshake
     - All the other custom Request classes live here with their Writeable input/output
   - `TransportResponse` 
     - `TransportHandshaker.HandshakeResponse` for tcp/handshake
     - `TransportService.HandshakeResponse` for transport/handshake
     - All the other custom Response classes live here with their Writeable input/output

This PR includes the commit from #9 so if that PR is merged first this needs rebasing; or merge this and close #9.

```
received <opensearch_sdk_py.transport.stream_input.StreamInput object at 0x1097028f0>, 55 byte(s)
	#b'ES\x00\x00\x001\x00\x00\x00\x00\x00\x00\x00\x08\x08\x08 \x0b\x83\x00\x00\x00\x1a\x00\x00\x00\x16internal:tcp/handshake\x00\x04\xa3\x8e\xb7A'
	['request', 'handshake'] b'ES', message=49 byte(s), request_id=8, status=8, version=2.10.0.99
	action: internal:tcp/handshake
	parsed TCP handshake, OpenSearch 3.0.0.99, returning a response

sent handshake response, 29 byte(s):
	#b'ES\x00\x00\x00\x17\x00\x00\x00\x00\x00\x00\x00\x08\t\x08 \x0b\x83\x00\x00\x00\x02\x00\x00\xa3\x8e\xb7A'
	['response', 'handshake'] b'ES', message=23 byte(s), request_id=8, status=9, version=2.10.0.99

received <opensearch_sdk_py.transport.stream_input.StreamInput object at 0x109702da0>, 56 byte(s)
	#b'ES\x00\x00\x002\x00\x00\x00\x00\x00\x00\x00\t\x00\x08-\xc7#\x00\x00\x00 \x00\x00\x00\x1cinternal:transport/handshake\x00'
	['request'] b'ES', message=50 byte(s), request_id=9, status=0, version=3.0.0.99
	action: internal:transport/handshake
	parsed Transport handshake, returning a response

sent handshake response, 179 byte(s):
	#b'ES\x00\x00\x00\xad\x00\x00\x00\x00\x00\x00\x00\t\x01\x08-\xc7#\x00\x00\x00\x02\x00\x00\x01\x0bhello-world\x06nodeId\x0bephemeralId\t127.0.0.1\t127.0.0.1\x04\x7f\x00\x00\x01\t127.0.0.1\x00\x00\x04\xd2\x00\x04\x0fcluster_manager\x01m\x00\x04data\x01d\x01\x06ingest\x01i\x00\x15remote_cluster_client\x01r\x00\xa3\x8e\xb7A\nopensearch\xa3\x8e\xb7A'
	['response'] b'ES', message=173 byte(s), request_id=9, status=1, version=3.0.0.99

received <opensearch_sdk_py.transport.stream_input.StreamInput object at 0x109703010>, 475 byte(s)
	#b'ES\x00\x00\x01\xd5\x00\x00\x00\x00\x00\x00\x00\n\x00\x08-\xc7#\x00\x00\x00D\x01\x1c_system_index_access_allowed\x05false\x00\x00\x1dinternal:discovery/extensions\x00\trunTask-0\x169f9BpEd5ShWpZdBsXalh6A\x16DcHk5u0cS32tYOW8db0GVQ\t127.0.0.1\t127.0.0.1\x04\x7f\x00\x00\x01\t127.0.0.1\x00\x00$T\x02\x08testattr\x04test\x1fshard_indexing_pressure_enabled\x04true\x04\x0fcluster_manager\x01m\x00\x04data\x01d\x01\x06ingest\x01i\x00\x15remote_cluster_client\x01r\x00\xa3\x8e\xb7A\x0bhello-world\x0bhello-world\x16kZIVwKbsSzyNIs7MsiKftA\t127.0.0.1\t127.0.0.1\x04\x7f\x00\x00\x01\t127.0.0.1\x00\x00\x04\xd2\x00\x05\x0fcluster_manager\x01m\x00\x04data\x01d\x01\x06ingest\x01i\x00\x15remote_cluster_client\x01r\x00\x06search\x01s\x01\xa3\x8e\xb7A\xa3\x8e\xb7A\x00'
	['request'] b'ES', message=469 byte(s), request_id=10, status=0, version=3.0.0.99
	request headers: {'_system_index_access_allowed': 'false'}
	action: internal:discovery/extensions
	parsed Extension initialization request, returning a response

sent init response, 131 byte(s):
	#b'ES\x00\x00\x00}\x00\x00\x00\x00\x00\x00\x00\n\x01\x08-\xc7#\x00\x00\x00E\x02\x1c_system_index_access_allowed\x05false\x13extension_unique_id\x0bhello-world\x00\x0bhello-world\x02\tExtension\x0fActionExtension'
	['response'] b'ES', message=125 byte(s), request_id=10, status=1, version=3.0.0.99
```